### PR TITLE
Fixed Express Crane recipe generating Wide Express Crane

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -39,7 +39,7 @@ if mods["boblogistics"] then
 
 	register_crane("express-stack-inserter", "nco-wide-express-crane", true, nil)
 	register_crane("express-stack-filter-inserter", "nco-wide-express-filter-crane", true, nil)
-	register_crane("express-stack-inserter", "nco-express-crane", true, nil)
+	register_crane("express-stack-inserter", "nco-express-crane", false, nil)
 	register_crane("express-stack-filter-inserter", "nco-express-filter-crane", true, nil)
 end
 


### PR DESCRIPTION
I found a bug where the express-crane and wide-express-crane recipe ingredients were the same, and both produced the wide express crane. 

Seems like a simple issue where a boolean value needed changing in the data-updates.lua file.

I have made that change and tested it locally and the normal and wide crane now have different ingredients and produce the normal and wide variety as expected.